### PR TITLE
Added run once capability and mentions for teams

### DIFF
--- a/backend/jobs/CheckCertJob.go
+++ b/backend/jobs/CheckCertJob.go
@@ -78,6 +78,10 @@ func (c *CheckCertJob) Init(schedule string, level string, warningDays int, cert
 	return nil
 }
 
+func (c *CheckCertJob) RunNow() {
+	c.execute()
+}
+
 func (c *CheckCertJob) Start() {
 	c.running = true
 	go func() {

--- a/backend/jobs/CheckCertJob_test.go
+++ b/backend/jobs/CheckCertJob_test.go
@@ -94,6 +94,16 @@ func TestTryExecuteDue(t *testing.T) {
 	assert.True(t, notifier.executed)
 }
 
+func TestExecuteNow(t *testing.T) {
+	checkCertJob := &CheckCertJob{}
+	notifier := &mockNotifier{}
+	checkCertJob.Init("* * * * *", "", 0, certList, &mockNotifier{})
+	checkCertJob.notifier = notifier
+	checkCertJob.RunNow()
+
+	assert.True(t, notifier.executed)
+}
+
 func TestTryExecuteDueWarning(t *testing.T) {
 	checkCertJob := &CheckCertJob{}
 	notifier := &mockNotifier{}

--- a/backend/jobs/notificationTemplates.go
+++ b/backend/jobs/notificationTemplates.go
@@ -60,7 +60,13 @@ const teamsMessageTemplate = `{
 					"size": "large",
 					"weight": "bolder",
 					"wrap": true
-				},
+				},{{- if gt (len .Mentions) 0}}
+				{
+					"type": "TextBlock",
+					"text": "Attention: {{ range $index, $element := .Mentions}}{{if $index}}, {{end}}<at>{{$element}}</at>{{end}}",
+					"isSubtle": true,
+					"wrap": true
+				},{{- end}}
 				{
 					"type": "TextBlock",
 					"text": "{{ .Description }}",
@@ -116,7 +122,24 @@ const teamsMessageTemplate = `{
 					"title": "View Details",
 					"url": "{{ .NotificationUrl }}"
 				}
-			]{{end}}
+			]{{end}}{{if gt (len .Mentions) 0}},
+			"msteams": {
+                "entities": [
+					{{- $max := len (slice .Mentions 1)}}
+					{{- range $i, $item := .Mentions}}
+					{{- $shortNames := split $item "@"}}
+                    {
+						"type": "mention",
+						"text": "<at>{{$item}}</at>",
+						"mentioned": {
+							"id": "{{$item}}",
+							"name": "{{ index $shortNames 0 }}"
+						}
+					}{{if lt $i $max}},{{end}}
+					{{- end}}
+				]
+			}
+			{{- end}}
 		}
 	}]
 }`

--- a/backend/jobs/webHookNotifier_test.go
+++ b/backend/jobs/webHookNotifier_test.go
@@ -25,10 +25,32 @@ func TestWebHookNotifierExplicitInit(t *testing.T) {
 	})
 
 	WebHookNotifier := &WebHookNotifier{}
-	WebHookNotifier.Init(Teams, ts.URL, "title", "body", "url")
+	WebHookNotifier.Init(Teams, ts.URL, "title", "body", "url", "")
 	err := WebHookNotifier.Notify([]CertCheckNotification{})
 	assert.Nil(t, err)
 	assert.Equal(t, "{\n\t\"type\": \"message\",\n\t\"attachments\": [{\n\t\t\"contentType\": \"application/vnd.microsoft.card.adaptive\",\n\t\t\"content\": {\n\t\t\t\"type\": \"AdaptiveCard\",\n\t\t\t\"version\": \"1.5\",\n\t\t\t\"$schema\": \"http://adaptivecards.io/schemas/adaptive-card.json\",\n\t\t\t\"body\": [\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"TextBlock\",\n\t\t\t\t\t\"text\": \"title\",\n\t\t\t\t\t\"size\": \"large\",\n\t\t\t\t\t\"weight\": \"bolder\",\n\t\t\t\t\t\"wrap\": true\n\t\t\t\t},\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"TextBlock\",\n\t\t\t\t\t\"text\": \"body\",\n\t\t\t\t\t\"isSubtle\": true,\n\t\t\t\t\t\"wrap\": true\n\t\t\t\t},\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"Table\",\n\t\t\t\t\t\"columns\": [\n\t\t\t\t\t\t{\n\t\t\t\t\t\t\t\"width\": 2\n\t\t\t\t\t\t},\n\t\t\t\t\t\t{\n\t\t\t\t\t\t\t\"width\": 4\n\t\t\t\t\t\t}\n\t\t\t\t\t],\n\t\t\t\t\t\"rows\": [\n\t\t\t\t\t]\n\t\t\t\t}\n\t\t\t],\n\t\t\t\"actions\": [\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"Action.OpenUrl\",\n\t\t\t\t\t\"title\": \"View Details\",\n\t\t\t\t\t\"url\": \"url\"\n\t\t\t\t}\n\t\t\t]\n\t\t}\n\t}]\n}", result)
+}
+
+func TestWebHookNotifierWithMentionsExplicitInit(t *testing.T) {
+	mux := http.NewServeMux()
+	ts := httptest.NewUnstartedServer(mux)
+	ts.Start()
+	defer ts.Close()
+
+	var result string
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		defer r.Body.Close()
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(r.Body)
+		result = buf.String()
+	})
+
+	WebHookNotifier := &WebHookNotifier{}
+	WebHookNotifier.Init(Teams, ts.URL, "title", "body", "url", "me@lpains.net")
+	err := WebHookNotifier.Notify([]CertCheckNotification{})
+	assert.Nil(t, err)
+	assert.Equal(t, "{\n\t\"type\": \"message\",\n\t\"attachments\": [{\n\t\t\"contentType\": \"application/vnd.microsoft.card.adaptive\",\n\t\t\"content\": {\n\t\t\t\"type\": \"AdaptiveCard\",\n\t\t\t\"version\": \"1.5\",\n\t\t\t\"$schema\": \"http://adaptivecards.io/schemas/adaptive-card.json\",\n\t\t\t\"body\": [\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"TextBlock\",\n\t\t\t\t\t\"text\": \"title\",\n\t\t\t\t\t\"size\": \"large\",\n\t\t\t\t\t\"weight\": \"bolder\",\n\t\t\t\t\t\"wrap\": true\n\t\t\t\t},\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"TextBlock\",\n\t\t\t\t\t\"text\": \"Attention: <at>me@lpains.net</at>\",\n\t\t\t\t\t\"isSubtle\": true,\n\t\t\t\t\t\"wrap\": true\n\t\t\t\t},\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"TextBlock\",\n\t\t\t\t\t\"text\": \"body\",\n\t\t\t\t\t\"isSubtle\": true,\n\t\t\t\t\t\"wrap\": true\n\t\t\t\t},\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"Table\",\n\t\t\t\t\t\"columns\": [\n\t\t\t\t\t\t{\n\t\t\t\t\t\t\t\"width\": 2\n\t\t\t\t\t\t},\n\t\t\t\t\t\t{\n\t\t\t\t\t\t\t\"width\": 4\n\t\t\t\t\t\t}\n\t\t\t\t\t],\n\t\t\t\t\t\"rows\": [\n\t\t\t\t\t]\n\t\t\t\t}\n\t\t\t],\n\t\t\t\"actions\": [\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"Action.OpenUrl\",\n\t\t\t\t\t\"title\": \"View Details\",\n\t\t\t\t\t\"url\": \"url\"\n\t\t\t\t}\n\t\t\t],\n\t\t\t\"msteams\": {\n                \"entities\": [\n                    {\n\t\t\t\t\t\t\"type\": \"mention\",\n\t\t\t\t\t\t\"text\": \"<at>me@lpains.net</at>\",\n\t\t\t\t\t\t\"mentioned\": {\n\t\t\t\t\t\t\t\"id\": \"me@lpains.net\",\n\t\t\t\t\t\t\t\"name\": \"me\"\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\t\t\t\t]\n\t\t\t}\n\t\t}\n\t}]\n}", result)
 }
 
 func TestWebHookNotifierImplicitInit(t *testing.T) {
@@ -47,7 +69,7 @@ func TestWebHookNotifierImplicitInit(t *testing.T) {
 	})
 
 	WebHookNotifier := &WebHookNotifier{}
-	WebHookNotifier.Init(Teams, ts.URL, "", "The following certificates were checked on today", "")
+	WebHookNotifier.Init(Teams, ts.URL, "", "The following certificates were checked on today", "", "")
 	err := WebHookNotifier.Notify([]CertCheckNotification{})
 	assert.Nil(t, err)
 	assert.Equal(t, "{\n\t\"type\": \"message\",\n\t\"attachments\": [{\n\t\t\"contentType\": \"application/vnd.microsoft.card.adaptive\",\n\t\t\"content\": {\n\t\t\t\"type\": \"AdaptiveCard\",\n\t\t\t\"version\": \"1.5\",\n\t\t\t\"$schema\": \"http://adaptivecards.io/schemas/adaptive-card.json\",\n\t\t\t\"body\": [\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"TextBlock\",\n\t\t\t\t\t\"text\": \"Sharp Cert Manager Summary\",\n\t\t\t\t\t\"size\": \"large\",\n\t\t\t\t\t\"weight\": \"bolder\",\n\t\t\t\t\t\"wrap\": true\n\t\t\t\t},\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"TextBlock\",\n\t\t\t\t\t\"text\": \"The following certificates were checked on today\",\n\t\t\t\t\t\"isSubtle\": true,\n\t\t\t\t\t\"wrap\": true\n\t\t\t\t},\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"Table\",\n\t\t\t\t\t\"columns\": [\n\t\t\t\t\t\t{\n\t\t\t\t\t\t\t\"width\": 2\n\t\t\t\t\t\t},\n\t\t\t\t\t\t{\n\t\t\t\t\t\t\t\"width\": 4\n\t\t\t\t\t\t}\n\t\t\t\t\t],\n\t\t\t\t\t\"rows\": [\n\t\t\t\t\t]\n\t\t\t\t}\n\t\t\t]\n\t\t}\n\t}]\n}", result)
@@ -69,7 +91,7 @@ func TestTeamsWebHookNotifierWithData(t *testing.T) {
 	})
 
 	WebHookNotifier := &WebHookNotifier{}
-	WebHookNotifier.Init(Teams, ts.URL, "", "The following certificates were checked on today", "")
+	WebHookNotifier.Init(Teams, ts.URL, "", "The following certificates were checked on today", "", "")
 	err := WebHookNotifier.Notify([]CertCheckNotification{
 		{Hostname: "host1", IsValid: true},
 	})
@@ -93,7 +115,7 @@ func TestSlackWebHookNotifierWithData(t *testing.T) {
 	})
 
 	WebHookNotifier := &WebHookNotifier{}
-	WebHookNotifier.Init(Slack, ts.URL, "", "The following certificates were checked on today", "")
+	WebHookNotifier.Init(Slack, ts.URL, "", "The following certificates were checked on today", "", "")
 	err := WebHookNotifier.Notify([]CertCheckNotification{
 		{Hostname: "host1", IsValid: true},
 	})
@@ -112,7 +134,7 @@ func TestWebHookNotifierBadResponseCode(t *testing.T) {
 	})
 
 	WebHookNotifier := &WebHookNotifier{}
-	WebHookNotifier.Init(Teams, ts.URL, "", "", "")
+	WebHookNotifier.Init(Teams, ts.URL, "", "", "", "")
 	err := WebHookNotifier.Notify([]CertCheckNotification{})
 	assert.Equal(t, "error sending notification to Teams", err.Error())
 }


### PR DESCRIPTION
This pull request introduces several enhancements to the `backend/jobs` package, focusing on adding mentions in notifications, improving the `CheckCertJob` functionality, and allowing a headless mode for the web server. The most important changes include adding support for mentions in Teams notifications, adding a `RunNow` method to `CheckCertJob`, and updating the web server to support headless mode.

### Notification Enhancements:
* Added support for mentions in Teams notifications by modifying the `teamsMessageTemplate` and updating the `WebHookNotifier` to handle mentions. (`backend/jobs/notificationTemplates.go`: [[1]](diffhunk://#diff-7013209f4ac6a8cf2eb5856958058c34227438046bba577b2e1f857374b807bfL63-R69) [[2]](diffhunk://#diff-7013209f4ac6a8cf2eb5856958058c34227438046bba577b2e1f857374b807bfL119-R142) (`backend/jobs/webHookNotifier.go`: [[3]](diffhunk://#diff-b73aabea1d359e4e4b841c9d8fb97a1f5fa18d89a8d6c5e9bb3f82d65ee211cfR19) [[4]](diffhunk://#diff-b73aabea1d359e4e4b841c9d8fb97a1f5fa18d89a8d6c5e9bb3f82d65ee211cfR29-R32) [[5]](diffhunk://#diff-b73aabea1d359e4e4b841c9d8fb97a1f5fa18d89a8d6c5e9bb3f82d65ee211cfR46-R54) [[6]](diffhunk://#diff-b73aabea1d359e4e4b841c9d8fb97a1f5fa18d89a8d6c5e9bb3f82d65ee211cfR65) [[7]](diffhunk://#diff-b73aabea1d359e4e4b841c9d8fb97a1f5fa18d89a8d6c5e9bb3f82d65ee211cfL82-R99)
* Updated tests to verify the new mentions functionality. (`backend/jobs/webHookNotifier_test.go`: [[1]](diffhunk://#diff-0e91caabf8c5b3550b5be238765fbfceed7efe02e765c6c67c3aec9eaf969adfL28-R55) [[2]](diffhunk://#diff-0e91caabf8c5b3550b5be238765fbfceed7efe02e765c6c67c3aec9eaf969adfL50-R72) [[3]](diffhunk://#diff-0e91caabf8c5b3550b5be238765fbfceed7efe02e765c6c67c3aec9eaf969adfL72-R94) [[4]](diffhunk://#diff-0e91caabf8c5b3550b5be238765fbfceed7efe02e765c6c67c3aec9eaf969adfL96-R118) [[5]](diffhunk://#diff-0e91caabf8c5b3550b5be238765fbfceed7efe02e765c6c67c3aec9eaf969adfL115-R137)

### `CheckCertJob` Enhancements:
* Added a `RunNow` method to `CheckCertJob` to allow immediate execution. (`backend/jobs/CheckCertJob.go`: [backend/jobs/CheckCertJob.goR81-R84](diffhunk://#diff-31654c38d8d6922117dd36cea01d93c9125d9a0f9de7805afed9133f7a72337dR81-R84))
* Added a test to verify the `RunNow` method functionality. (`backend/jobs/CheckCertJob_test.go`: [backend/jobs/CheckCertJob_test.goR97-R106](diffhunk://#diff-bbb07a1ee5e784098f8c9d700ad3c92fb66a38bda91e84992c8620fc4b62d8e7R97-R106))

### Web Server Enhancements:
* Introduced a headless mode to skip starting the web server when certain conditions are met. (`backend/main.go`: [[1]](diffhunk://#diff-dec704b60ebde2632503812758e7db9b3b1f663f8b1ac015e670644b5396a2f0R92-R98) [[2]](diffhunk://#diff-dec704b60ebde2632503812758e7db9b3b1f663f8b1ac015e670644b5396a2f0R151-R172)
* Added a `runOnce` function to execute the `checkCertJob` once if the schedule is not set or headless mode is enabled. (`backend/main.go`: [backend/main.goR183](diffhunk://#diff-dec704b60ebde2632503812758e7db9b3b1f663f8b1ac015e670644b5396a2f0R183))

### Miscellaneous:
* Imported the `strings` package in `webHookNotifier.go` to support the new functionality. (`backend/jobs/webHookNotifier.go`: [backend/jobs/webHookNotifier.goR8](diffhunk://#diff-b73aabea1d359e4e4b841c9d8fb97a1f5fa18d89a8d6c5e9bb3f82d65ee211cfR8))