### PR TITLE
Fix HEALESS default value

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ docker run -it -p 8000:8000 \
 
 ## Running locally
 ### Prerequisites
-* Go 1.16+
+* Go 1.23+
 * Tailwindcss CLI
 
 ### CLone the repo

--- a/src/jobs/CheckCertJob.go
+++ b/src/jobs/CheckCertJob.go
@@ -12,6 +12,7 @@ import (
 
 type Notifier interface {
 	Notify(result []CertCheckNotification) error
+	IsReady() bool
 }
 
 type CheckCertJob struct {
@@ -54,7 +55,7 @@ func (c *CheckCertJob) Init(schedule string, level string, warningDays int, cert
 		return fmt.Errorf("a valid cron schedule is required")
 	}
 
-	if notifier == nil {
+	if notifier == nil || !notifier.IsReady() {
 		log.Printf("A valid notifier is required")
 		return fmt.Errorf("a valid notifier is required")
 	}

--- a/src/jobs/CheckCertJob_test.go
+++ b/src/jobs/CheckCertJob_test.go
@@ -16,6 +16,10 @@ func (m *mockNotifier) Notify(result []CertCheckNotification) error {
 	return nil
 }
 
+func (m *mockNotifier) IsReady() bool {
+	return true
+}
+
 var certList = []models.CheckCertItem{
 	{Name: "blog.lpains.net", Url: "https://blog.lpains.net", Type: models.CertCheckURL},
 }

--- a/src/jobs/emptyNotifier.go
+++ b/src/jobs/emptyNotifier.go
@@ -7,3 +7,7 @@ type EmptyNotifier struct{}
 func (m *EmptyNotifier) Notify(result []models.CertCheckResult) error {
 	return nil
 }
+
+func (m *EmptyNotifier) IsReady() bool {
+	return true
+}

--- a/src/jobs/webHookNotifier.go
+++ b/src/jobs/webHookNotifier.go
@@ -109,3 +109,7 @@ func (m *WebHookNotifier) getClient() *http.Client {
 
 	return m.httpClient
 }
+
+func (m *WebHookNotifier) IsReady() bool {
+	return m.WebhookUrl != ""
+}

--- a/src/main.go
+++ b/src/main.go
@@ -89,9 +89,9 @@ func stopJobs() {
 }
 
 func startWebServer(siteList []models.CheckCertItem) {
-	headless, ok := os.LookupEnv("HEADLESS")
+	headless, _ := os.LookupEnv("HEADLESS")
 
-	if !ok || headless == "true" {
+	if headless == "true" {
 		log.Println("Running in headless mode. Skipping web server start.")
 		return
 	}


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and reliability of the notification system in the `CheckCertJob` and to update the prerequisites in the `readme.md` file. The most important changes include adding a readiness check to the notifier interface, updating the Go version requirement, and modifying the web server start logic.

Notifier interface enhancements:

* [`src/jobs/CheckCertJob.go`](diffhunk://#diff-35775bc405a4c0ef6d95653cc05b8a5f70be8802be2895633a8196dcb8e2ef6eR15): Added `IsReady` method to the `Notifier` interface and updated the `Init` function to check if the notifier is ready. [[1]](diffhunk://#diff-35775bc405a4c0ef6d95653cc05b8a5f70be8802be2895633a8196dcb8e2ef6eR15) [[2]](diffhunk://#diff-35775bc405a4c0ef6d95653cc05b8a5f70be8802be2895633a8196dcb8e2ef6eL57-R58)
* [`src/jobs/CheckCertJob_test.go`](diffhunk://#diff-d026bc798682504961ee8c95067873e93d53623aed71da64f4b2e96f3c409c3fR19-R22): Implemented the `IsReady` method in the `mockNotifier` for testing purposes.
* [`src/jobs/emptyNotifier.go`](diffhunk://#diff-846026f020e09c4d96d8721fbd744126069091d4eab8c9768bf317b4b17d91deR10-R13): Implemented the `IsReady` method in the `EmptyNotifier` to always return true.
* [`src/jobs/webHookNotifier.go`](diffhunk://#diff-06739766a8f65a29798e713c0b3fc60c206e71ed207605f7a45a1562c4746733R112-R115): Implemented the `IsReady` method in the `WebHookNotifier` to check if the `WebhookUrl` is not empty.

Documentation update:

* [`readme.md`](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L28-R28): Updated the Go version requirement from 1.16+ to 1.23+.

Web server start logic modification:

* [`src/main.go`](diffhunk://#diff-9e185f29fa355d7dd8fdd9c9ff1d0723b85206aa7d37c4eec93997005dc291ebL92-R94): Simplified the logic for starting the web server by removing the unnecessary check for the `HEADLESS` environment variable.