### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: PR Validation
+permissions:
+  contents: read
 
 on:
   release: 


### PR DESCRIPTION
Potential fix for [https://github.com/jlucaspains/sharp-cert-manager/security/code-scanning/15](https://github.com/jlucaspains/sharp-cert-manager/security/code-scanning/15)

To fix the problem, explicitly declare a `permissions` block so that the `GITHUB_TOKEN` used in this workflow is limited to the minimum required. Since the workflow primarily checks out the repository and uses Docker actions that rely on Docker Hub credentials (not `GITHUB_TOKEN`) for pushing images, the minimal safe permission is `contents: read`. This satisfies CodeQL’s recommendation and adheres to least privilege.

The best way to do this without changing existing functionality is to add a root-level `permissions` section just under the workflow `name:` (or under `on:`), so it applies to all jobs in the workflow. Specifically, in `.github/workflows/deploy.yml`, between line 3 (`name: PR Validation`) and line 5 (`on:`), insert:

```yml
permissions:
  contents: read
```

No imports or additional methods are needed; this is purely a GitHub Actions YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
