### PR TITLE
Added multi-arch builds and CLAUDE.md

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,23 +1,83 @@
-# This is a basic workflow to help you get started with Actions
-
-name: PR Validation
+name: Release
 permissions:
   contents: read
 
 on:
-  release: 
+  release:
     types: [created]
 
 jobs:
-  backend:
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/sharp-cred-manager
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v7
+        with:
+          name: digest-${{ matrix.platform == 'linux/amd64' && 'linux-amd64' || 'linux-arm64' }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download digests
+        uses: actions/download-artifact@v8
+        with:
+          pattern: digest-*
+          merge-multiple: true
+          path: /tmp/digests
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6
         with:
           images: |
             ${{ secrets.DOCKERHUB_USERNAME }}/sharp-cred-manager
@@ -26,23 +86,21 @@ jobs:
             type=raw,value=latest
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
-      - name: Build
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-      
+      - name: Create multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ secrets.DOCKERHUB_USERNAME }}/sharp-cred-manager@sha256:%s ' *)
+
       - name: Docker Hub Description
         uses: peter-evans/dockerhub-description@v5
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,84 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Project Does
+
+Sharp Cred Manager monitors TLS certificates (from websites and Azure Key Vault) and Azure Key Vault secrets for expiration. It provides a web dashboard and sends scheduled webhook notifications (Teams/Slack) when credentials approach expiration.
+
+## Commands
+
+**Run the web server:**
+```bash
+go run ./cmd/api/main.go
+```
+
+**Run the CLI tool:**
+```bash
+go run ./cmd/sharp-cred-manager/ check --url https://example.com --warning-threshold 90
+```
+
+**Run all tests:**
+```bash
+go test -cover ./...
+```
+
+**Run a single test:**
+```bash
+go test -v ./internal/handlers/ -run TestCheckCertStatus
+```
+
+**Generate CSS (required after frontend/styles.css changes):**
+```bash
+tailwindcss -i ./frontend/styles.css -o ./public/styles.css --minify
+```
+
+**Hot reload during development:**
+```bash
+air  # configured via .air.toml
+```
+
+**Build Docker image:**
+```bash
+docker build -f Dockerfile -t sharp-cred-manager .
+```
+
+## Architecture
+
+Two entry points:
+- `cmd/api/main.go` — Web server + background job orchestrator
+- `cmd/sharp-cred-manager/` — Cobra-based CLI tool
+
+Core packages under `internal/`:
+- `handlers/` — HTTP handlers serving both JSON API and server-side HTML (Go `html/template`)
+- `services/` — Business logic: TLS certificate validation (`certService.go`) and Azure Key Vault secret checks (`secretService.go`)
+- `jobs/` — Cron-scheduled background jobs (`CheckCredJob.go`) and webhook notification (`webHookNotifier.go`, `notificationTemplates.go`)
+- `models/` — Shared request/response structs
+- `midlewares/` — HTTP middleware (request logging)
+
+Frontend: `frontend/*.html` Go templates + HTMX for dynamic updates + Tailwind CSS. Compiled static assets go in `public/`.
+
+## Key Patterns
+
+**Configuration is entirely environment-based** — no config files at runtime. `godotenv` auto-loads `.env` in development. Numbered env vars define monitored resources:
+- `SITE_1..N` — websites to check
+- `AZUREKEYVAULTCERT_1..N` — Key Vault certificate URLs
+- `AZUREKEYVAULTSECRET_1..N` — Key Vault secret URLs
+- `CHECK_CRED_JOB_SCHEDULE` — cron expression for background checks
+- `WEBHOOK_URL` + `WEBHOOK_TYPE` (teams/slack) — notification targets
+- `WEB_HOST_PORT` (default `:8000`), `CERT_WARNING_VALIDITY_DAYS` (default 30), `SECRET_WARNING_VALIDITY_DAYS` (default 30)
+- `HEADLESS=true` — skip web server, run jobs only
+- Azure auth: `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`
+
+**HTTP routing** uses Go's standard `http.NewServeMux()` with method-prefixed patterns (`GET /api/check-cert`). Handlers are methods on a `Handlers` struct registered in `cmd/api/main.go`.
+
+**Frontend pattern**: Pages load skeleton placeholders, then HTMX fetches real data via `hx-get` on page load. Templates are in `frontend/`, served from memory at startup.
+
+**Notifier interface** (`Notify()`, `IsReady()`) decouples job scheduling from webhook dispatch. `emptyNotifier` is a no-op when no webhook is configured. Adding a new credential type means adding a new `CheckNotificationGroup` to `CheckCredJob`.
+
+**Azure auth** uses `azidentity.NewDefaultAzureCredential()` — supports all standard Azure credential chains.
+
+## CI/CD
+
+- **PRs**: SonarCloud scan, Docker build test, Go tests with coverage posted to PR
+- **Releases**: Docker image built and pushed to Docker Hub with semver tags + latest; Docker Hub description updated from `readme.md`

--- a/specs/multi-arch-docker-build.md
+++ b/specs/multi-arch-docker-build.md
@@ -1,0 +1,92 @@
+# Multi-Architecture Docker Build (linux/amd64 + linux/arm64)
+
+## Problem Statement
+The current `deploy.yml` workflow builds and pushes a single `linux/amd64` Docker image. Users running on ARM64 hosts (e.g., Raspberry Pi, AWS Graviton, Apple Silicon via Docker) must rely on emulation. We want to publish a proper multi-arch manifest so Docker automatically pulls the correct image for the host architecture.
+
+## Key Decisions
+- **Runner strategy**: Use native GitHub-hosted runners (`ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64) instead of QEMU emulation. Both are free for public repositories.
+- **Publish strategy**: Each platform job pushes its image by digest (no tag). A final merge job combines the digests into a single multi-arch manifest under the existing tags (`latest`, semver).
+- **Digest passing**: Use `actions/upload-artifact` / `actions/download-artifact` to pass per-platform digests from build jobs to the merge job.
+- **Action versions**: Bump all Docker and checkout actions to their latest versions while touching the file.
+- **Docker Hub description**: Keep the description update step in the merge job only (runs once, after both images are published).
+- **No Dockerfile changes**: The existing multi-stage Dockerfile works as-is. Go produces static binaries and the `scratch`-based final image is architecture-agnostic from a Dockerfile perspective.
+
+## Architecture Overview
+
+### New Workflow Structure
+```
+deploy.yml (trigger: release created)
+│
+├── job: build (matrix)
+│   ├── matrix[0]: runner=ubuntu-latest,    platform=linux/amd64
+│   └── matrix[1]: runner=ubuntu-24.04-arm, platform=linux/arm64
+│   │
+│   └── steps:
+│       - checkout
+│       - docker/login-action
+│       - docker/metadata-action        (image name only, no tags — tags set in merge)
+│       - docker/setup-buildx-action
+│       - docker/build-push-action      (push-by-digest=true, no tag)
+│       - upload digest as artifact
+│
+└── job: merge (needs: build)
+    └── steps:
+        - download all digest artifacts
+        - docker/login-action
+        - docker/metadata-action        (produces final semver + latest tags)
+        - docker/buildx-imagetools      (create manifest from digests + attach tags)
+        - peter-evans/dockerhub-description
+```
+
+### Digest Artifact Convention
+Each build job exports the image digest and uploads it as an artifact named `digest-<sanitized-platform>` (e.g., `digest-linux-amd64`, `digest-linux-arm64`). The merge job downloads all artifacts matching `digest-*` and constructs the `imagetools create` command.
+
+---
+
+## Tasks
+
+### 1. Update deploy.yml – Build Job (Matrix)
+> Status: Complete
+
+- Replace the single `backend` job with a `build` job using a matrix strategy:
+  ```yaml
+  strategy:
+    fail-fast: false
+    matrix:
+      include:
+        - platform: linux/amd64
+          runner: ubuntu-latest
+        - platform: linux/arm64
+          runner: ubuntu-24.04-arm
+  ```
+- Set `runs-on: ${{ matrix.runner }}`
+- Use `docker/metadata-action@v6` to produce the image name (no tags needed at this stage)
+- Use `docker/setup-buildx-action@v4`
+- Use `docker/build-push-action@v7` with:
+  - `platforms: ${{ matrix.platform }}`
+  - `outputs: type=image,push-by-digest=true,name-canonical=true,push=true`
+  - Capture the digest from the step output (`steps.build.outputs.digest`)
+- Upload the digest as an artifact (`actions/upload-artifact@v7`), one file per platform
+
+### 2. Update deploy.yml – Merge Job
+> Status: Complete
+
+- Add a `merge` job with `needs: build` running on `ubuntu-latest`
+- Download all digest artifacts (`actions/download-artifact@v8` with `pattern: digest-*`, `merge-multiple: true`)
+- Use `docker/metadata-action@v6` to produce final semver + latest tags (same config as today)
+- Run `docker buildx imagetools create` as a shell step to create the multi-arch manifest:
+  - Buildx is already available after `docker/setup-buildx-action`
+  - Input: all downloaded digests
+  - Tags: from metadata-action output
+- Move the `peter-evans/dockerhub-description@v5` step into this job
+
+### 3. Bump Action Versions
+> Status: Complete
+
+- `actions/checkout@v3` → `actions/checkout@v4`
+- `docker/metadata-action@v4` → `docker/metadata-action@v6`
+- `docker/login-action@v2` → `docker/login-action@v4`
+- `docker/setup-buildx-action@v2` → `docker/setup-buildx-action@v4`
+- `docker/build-push-action@v4` → `docker/build-push-action@v7`
+- `actions/upload-artifact` (new) → `v7`
+- `actions/download-artifact` (new) → `v8`


### PR DESCRIPTION
This pull request introduces multi-architecture Docker image builds (linux/amd64 and linux/arm64) to the CI/CD pipeline, ensuring users on both x86 and ARM platforms receive native images. It restructures the GitHub Actions workflow to use a build matrix, adds a manifest merge step, and updates all Docker-related actions to their latest versions. Additionally, it documents the new approach and provides guidance for contributors and AI code assistants.

**CI/CD Pipeline: Multi-Arch Docker Build and Workflow Improvements**

*Multi-architecture Docker support:*
- The `deploy.yml` workflow now builds Docker images for both `linux/amd64` and `linux/arm64` using a matrix job, each on a native runner. Images are pushed by digest, and a separate merge job creates a multi-arch manifest with the correct tags. This ensures native images for all major platforms. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L12-R103) [[2]](diffhunk://#diff-1d5ae902ee40fca3c9d084d78abc0fc0d30ab8be92b36d7621636c296514aae8R1-R92)

*Workflow modernization and reliability:*
- All Docker and checkout GitHub Actions are updated to their latest major versions for improved reliability and security. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L12-R103) [[2]](diffhunk://#diff-1d5ae902ee40fca3c9d084d78abc0fc0d30ab8be92b36d7621636c296514aae8R1-R92)
- The workflow name is changed from "PR Validation" to "Release" to better reflect its purpose.

*Documentation and contributor experience:*
- Adds `CLAUDE.md`, a comprehensive guide for contributors and AI code assistants, detailing project purpose, commands, architecture, key patterns, and CI/CD process.
- Adds a technical specification document `specs/multi-arch-docker-build.md` describing the rationale, decisions, and implementation details for the new multi-arch Docker build process.