### PR TITLE
Adjusted deploy release to tag image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: ${{ matrix.platform }}
-          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ secrets.DOCKERHUB_USERNAME }}/sharp-cred-manager,push-by-digest=true,name-canonical=true,push=true
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Export digest


### PR DESCRIPTION
This pull request updates the Docker image build configuration in the deployment workflow to explicitly set the image name using the Docker Hub username secret.

Deployment workflow update:

* Updated the `outputs` parameter in the `jobs:` section of `.github/workflows/deploy.yml` to set the Docker image name to use the `${{ secrets.DOCKERHUB_USERNAME }}/sharp-cred-manager` format, ensuring images are correctly named and pushed to the intended Docker Hub repository.